### PR TITLE
Bump logback version to 1.3.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
          When possible, we advise using the relevant groupId and version
          properties for your dependencies rather than hardcoding them. -->
 
-    <logback.version>1.2.9</logback.version>
+    <logback.version>1.3.14</logback.version>
     <testng.version>6.8</testng.version>
     <ome-common.version>6.0.9</ome-common.version>
 


### PR DESCRIPTION
Proposed as a replacement for #16 and #17

As the overarching plan is to bump slf4j-api to 2.x in the upcoming `ome-common` release, we should start tracking the logback 1.3.x line rather than 1.2.x.
Note another commit will be required to bump `ome-common` to the new release including the `slf4j-api` version bump. Happy to include it as part of this PR if the component is already available on Maven Central