### PR TITLE
Use Maven profiles to handle different versions of TestNG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
          properties for your dependencies rather than hardcoding them. -->
 
     <logback.version>1.3.14</logback.version>
-    <testng.version>6.8</testng.version>
     <ome-common.version>6.0.21</ome-common.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
@@ -121,12 +120,6 @@
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-common</artifactId>
       <version>${ome-common.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>${testng.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -397,6 +390,34 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jdk8-only</id>
+      <activation>
+        <jdk>(,11)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>7.5</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>jdk11+</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>7.9.0</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
       <artifactId>ome-common</artifactId>
       <version>${ome-common.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -396,28 +402,18 @@
       <activation>
         <jdk>(,11)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.testng</groupId>
-          <artifactId>testng</artifactId>
-          <version>7.5</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <testng.version>7.5</testng.version>
+      </properties>
     </profile>
     <profile>
       <id>jdk11+</id>
       <activation>
         <jdk>[11,)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.testng</groupId>
-          <artifactId>testng</artifactId>
-          <version>7.9.0</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <testng.version>7.9.0</testng.version>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
See also https://github.com/ome/ome-common-java/pull/88

For JDK8, bump org.testng:testng to the last supported release for this version i.e. 7.5
For JDK11+, bump org.testng:testng to the latest release 7.9.0