### PR TITLE
Bump ome-common version to 6.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 
     <logback.version>1.3.14</logback.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.21</ome-common.version>
+    <ome-common.version>6.0.22</ome-common.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Bumping ome-common to the latest version 6.0.22