### PR TITLE
Bump ome-common to 6.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
          properties for your dependencies rather than hardcoding them. -->
 
     <logback.version>1.3.15</logback.version>
-    <ome-common.version>6.0.22</ome-common.version>
+    <ome-common.version>6.0.25</ome-common.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Similar to https://github.com/ome/ome-model/pull/205
This might not be strictly required but as we will release `ome-metakit` with #25, we might as well update `ome-common` to be consistent with the latest release