### PR TITLE
Require Java 11 at runtime, build on Java 21/25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,15 +15,15 @@ jobs:
       contents: read
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install # default is install
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -37,7 +37,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create a GitHub release
         run: gh release create --generate-notes "${GITHUB_REF#refs/tags/}"
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        java: [21, 25]
+        java: [11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ following before submitting a pull request:
 
  * verify that the branch merges cleanly into ```master```
  * verify that the branch compiles using Maven
- * verify that the branch does not use syntax or API specific to Java 1.8+
+ * verify that the branch does not use syntax or API specific to Java > 11
  * make sure that your commits contain the correct authorship information and,
    if necessary, a signed-off-by line
  * make sure that the commit messages or pull request comment contains

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
          properties for your dependencies rather than hardcoding them. -->
 
     <logback.version>1.3.16</logback.version>
-    <ome-common.version>6.1.1</ome-common.version>
+    <ome-common.version>6.3.0</ome-common.version>
     <testng.version>7.9.0</testng.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
          When possible, we advise using the relevant groupId and version
          properties for your dependencies rather than hardcoding them. -->
 
-    <logback.version>1.3.16</logback.version>
+    <logback.version>1.5.34</logback.version>
     <ome-common.version>6.3.0</ome-common.version>
     <testng.version>7.9.0</testng.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 
     <logback.version>1.3.16</logback.version>
     <ome-common.version>6.1.1</ome-common.version>
+    <testng.version>7.9.0</testng.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -136,8 +137,6 @@
         <version>3.14.0</version>
         <!-- Require the Java 11 platform. -->
         <configuration>
-          <source>11</source>
-          <target>11</target>
           <release>11</release>
         </configuration>
       </plugin>
@@ -368,15 +367,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk11+</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <properties>
-        <testng.version>7.9.0</testng.version>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,11 @@
 	<groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.14.0</version>
-        <!-- Require the Java 8 platform. -->
+        <!-- Require the Java 11 platform. -->
         <configuration>
-          <source>8</source>
-          <target>8</target>
-          <release>8</release>
+          <source>11</source>
+          <target>11</target>
+          <release>11</release>
         </configuration>
       </plugin>
 
@@ -368,15 +368,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk8-only</id>
-      <activation>
-        <jdk>(,11)</jdk>
-      </activation>
-      <properties>
-        <testng.version>7.5</testng.version>
-      </properties>
     </profile>
     <profile>
       <id>jdk11+</id>


### PR DESCRIPTION
Prerequisite to merging #32. See https://www.openmicroscopy.org/2026/03/24/end-of-java-8-support.html.